### PR TITLE
feat/#22 프로그래스 바 컴포넌트 제작

### DIFF
--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/View+Scale.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/View+Scale.swift
@@ -1,0 +1,14 @@
+//
+//  View+Scale.swift
+//  Cherrish-iOS
+//
+//  Created by 송성용 on 1/12/26.
+//
+
+import SwiftUI
+
+extension View {
+    func scaleX(_ scale: CGFloat) -> some View {
+        self.scaleEffect(x: scale, y: 1, anchor: .leading)
+    }
+}

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/ProgressBar.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/ProgressBar.swift
@@ -1,0 +1,47 @@
+//
+//  ProgressBar.swift
+//  Cherrish-iOS
+//
+//  Created by 송성용 on 1/9/26.
+//
+
+import SwiftUI
+
+struct ProgressBar: View {
+    var totalSteps: Int
+    var currentStep: Int
+    
+    private let backgroundColor: Color = Color(.gray300)
+    private let progressColor: Color = Color(.gray800)
+    private let height: CGFloat = 4
+    private let cornerRadius: CGFloat = 76
+    private let spacing: CGFloat = 4
+    
+    @State private var isAppeared = false
+    
+    var body: some View {
+        HStack(spacing: spacing) {
+            ForEach(0..<totalSteps, id: \.self) { index in
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(index < currentStep ? progressColor : backgroundColor)
+                    .frame(height: height)
+                    .scaleX(isAppeared ? 1 : 0)
+                    .animation(
+                        .easeOut(duration: 0.4).delay(Double(index) * 0.08),
+                        value: isAppeared
+                    )
+            }
+        }
+        .frame(height: height)
+        .onAppear {
+            isAppeared = true
+        }
+    }
+}
+
+extension View {
+    func scaleX(_ scale: CGFloat) -> some View {
+        self.scaleEffect(x: scale, y: 1, anchor: .leading)
+    }
+}
+

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/ProgressBar.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/ProgressBar.swift
@@ -46,10 +46,3 @@ struct ProgressBar: View {
         }
     }
 }
-
-extension View {
-    func scaleX(_ scale: CGFloat) -> some View {
-        self.scaleEffect(x: scale, y: 1, anchor: .leading)
-    }
-}
-

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/ProgressBar.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/ProgressBar.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ProgressBar: View {
-    var totalSteps: Int
+    let totalSteps: Int
     @Binding var currentStep: Int
     
     private let backgroundColor: Color = Color(.gray300)

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/ProgressBar.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/ProgressBar.swift
@@ -9,27 +9,35 @@ import SwiftUI
 
 struct ProgressBar: View {
     var totalSteps: Int
-    var currentStep: Int
+    @Binding var currentStep: Int
     
     private let backgroundColor: Color = Color(.gray300)
     private let progressColor: Color = Color(.gray800)
     private let height: CGFloat = 4
     private let cornerRadius: CGFloat = 76
-    private let spacing: CGFloat = 4
+    private let spacing: CGFloat = 4    
     
     @State private var isAppeared = false
     
     var body: some View {
         HStack(spacing: spacing) {
             ForEach(0..<totalSteps, id: \.self) { index in
-                RoundedRectangle(cornerRadius: cornerRadius)
-                    .fill(index < currentStep ? progressColor : backgroundColor)
-                    .frame(height: height)
-                    .scaleX(isAppeared ? 1 : 0)
-                    .animation(
-                        .easeOut(duration: 0.4).delay(Double(index) * 0.08),
-                        value: isAppeared
-                    )
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .fill(backgroundColor)
+                        .frame(height: height)
+                    
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .fill(progressColor)
+                        .frame(height: height)
+                        .scaleX(index < currentStep ? 1 : 0)
+                        .animation(.easeOut(duration: 0.5), value: currentStep)
+                }
+                .scaleX(isAppeared ? 1 : 0)
+                .animation(
+                    .easeOut(duration: 0.3).delay(Double(index) * 0.08),
+                    value: isAppeared
+                )
             }
         }
         .frame(height: height)


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #22 
## 📄 작업 내용
- 프로그래스 바 컴포넌트 제작
- 등장 애니메이션 적용
- **단계 변경 시 왼쪽→오른쪽으로 차오르는 애니메이션 적용**
- **외부에서 동적으로 단계 제어 가능하도록 `@Binding` 적용**

## 이렇게 보여요
![Simulator Screen Recording - iPhone 17 Pro - 2026-01-11 at 18 53 18](https://github.com/user-attachments/assets/d839fbb7-0a1d-418c-9ab2-c9f6b146a5eb)



## 💻 주요 코드 설명
`ProgressBar.swift`
#### Figma에 연속적인 프로그래스바가 아닌 단계별로 끊기는 형태여서 다음과 같이 구현하였습니다.
#### 항상 고정되는 값들은 private let으로 관리 
```swift
private let backgroundColor: Color = Color(.gray300)
private let progressColor: Color = Color(.gray800)
private let height: CGFloat = 4
private let cornerRadius: CGFloat = 76
private let spacing: CGFloat = 4
```
---
#### @Binding을 통한 외부 상태 연동
```swift
var totalSteps: Int
@Binding var currentStep: Int
```
- 호출하는 화면에서 `@State`로 `currentStep`을 관리
- 버튼 등을 통해 `currentStep`을 변경하면 프로그래스바가 자동으로 업데이트
---
#### ZStack 레이어 구조
```swift
ZStack(alignment: .leading) {
    RoundedRectangle(cornerRadius: cornerRadius)
        .fill(backgroundColor)
        .frame(height: height)
    
    RoundedRectangle(cornerRadius: cornerRadius)
        .fill(progressColor)
        .frame(height: height)
        .scaleX(index < currentStep ? 1 : 0)
        .animation(.easeOut(duration: 0.5), value: currentStep)
}
```
- 백그라운드(회색)와 프로그레스(진한색)를 레이어로 분리
- 프로그레스가 `scaleX` 애니메이션으로 왼쪽에서 오른쪽으로 차오름
---
#### scaleX 헬퍼 함수
```swift
extension View {
    func scaleX(_ scale: CGFloat) -> some View {
        self.scaleEffect(x: scale, y: 1, anchor: .leading)
    }
}
```
- X축만 스케일링, Y축은 고정 (높이 유지)
- `anchor: .leading` → 왼쪽 끝을 기준점으로 확대/축소
---
#### 등장 애니메이션
```swift
@State private var isAppeared = false
.scaleX(isAppeared ? 1 : 0)
.animation(
    .easeOut(duration: 0.3).delay(Double(index) * 0.08),
    value: isAppeared
)
.onAppear {
    isAppeared = true
}
```
- 각 조각마다 0.08초씩 딜레이 추가하여 순차 등장 효과
---
#### 단계 변경 애니메이션
```swift
.scaleX(index < currentStep ? 1 : 0)
.animation(.easeOut(duration: 0.5), value: currentStep)
```
- `currentStep`이 변경될 때마다 0.5초 동안 왼쪽→오른쪽으로 차오르는 애니메이션
---
## 사용 방법
```swift
struct SomeView: View {
    @State private var currentStep: Int = 0  // 항상 0으로 시작
    
    var body: some View {
        VStack {
            ProgressBar(totalSteps: 5, currentStep: $currentStep)
            
            Button("다음") {
                if currentStep < 5 {
                    currentStep += 1
                }
            }
        }
    }
}
```
## 👀 기타 더 이야기해볼 점
```swift
private let backgroundColor: Color = Color(.gray300)
private let progressColor: Color = Color(.gray800)
private let height: CGFloat = 4
private let cornerRadius: CGFloat = 76
private let spacing: CGFloat = 4
```
처럼 바뀌지 않는 값이어도 가독성, 유지보수를 생각해서 이렇게 작성했는데 어떻게 생각하세요??
