### PR TITLE
Feat/#36 Color ViewModifier 추가 및 Shadow, Color 디자인 시스템 반영

### DIFF
--- a/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/Color/green_1.colorset/Contents.json
+++ b/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/Color/green_1.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF3",
+          "green" : "0xFF",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/Color/green_2.colorset/Contents.json
+++ b/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/Color/green_2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB8",
+          "green" : "0xDC",
+          "red" : "0xBE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/Color/green_3.colorset/Contents.json
+++ b/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/Color/green_3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x42",
+          "green" : "0xD3",
+          "red" : "0x9A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/Color/shadow.colorset/Contents.json
+++ b/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/Color/shadow.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA7",
+          "green" : "0x98",
+          "red" : "0x90"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/View+Color.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/View+Color.swift
@@ -1,0 +1,96 @@
+//
+//  View+Color.swift
+//  Cherrish-iOS
+//
+
+import SwiftUI
+
+extension View {
+    func gray0() -> some View {
+        self.foregroundStyle(Color("gray_0"))
+    }
+    
+    func gray100() -> some View {
+        self.foregroundStyle(Color("gray_100"))
+    }
+    
+    func gray200() -> some View {
+        self.foregroundStyle(Color("gray_200"))
+    }
+    
+    func gray300() -> some View {
+        self.foregroundStyle(Color("gray_300"))
+    }
+    
+    func gray400() -> some View {
+        self.foregroundStyle(Color("gray_400"))
+    }
+    
+    func gray500() -> some View {
+        self.foregroundStyle(Color("gray_500"))
+    }
+    
+    func gray600() -> some View {
+        self.foregroundStyle(Color("gray_600"))
+    }
+    
+    func gray700() -> some View {
+        self.foregroundStyle(Color("gray_700"))
+    }
+    
+    func gray800() -> some View {
+        self.foregroundStyle(Color("gray_800"))
+    }
+    
+    func gray900() -> some View {
+        self.foregroundStyle(Color("gray_900"))
+    }
+    
+    func gray1000() -> some View {
+        self.foregroundStyle(Color("gray_1000"))
+    }
+    
+    func green1() -> some View {
+        self.foregroundStyle(Color("green_1"))
+    }
+    
+    func green2() -> some View {
+        self.foregroundStyle(Color("green_2"))
+    }
+    
+    func green3() -> some View {
+        self.foregroundStyle(Color("green_3"))
+    }
+    
+    func red100() -> some View {
+        self.foregroundStyle(Color("red_100"))
+    }
+    
+    func red200() -> some View {
+        self.foregroundStyle(Color("red_200"))
+    }
+    
+    func red300() -> some View {
+        self.foregroundStyle(Color("red_300"))
+    }
+    
+    func red400() -> some View {
+        self.foregroundStyle(Color("red_400"))
+    }
+    
+    func red500() -> some View {
+        self.foregroundStyle(Color("red_500"))
+    }
+    
+    func red600() -> some View {
+        self.foregroundStyle(Color("red_600"))
+    }
+    
+    func red700() -> some View {
+        self.foregroundStyle(Color("red_700"))
+    }
+    
+    func red800() -> some View {
+        self.foregroundStyle(Color("red_800"))
+    }
+}

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/View+Shadow.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/View+Shadow.swift
@@ -9,7 +9,7 @@ struct CherrishShadow: ViewModifier {
     func body(content: Content) -> some View {
         content
             .shadow(
-                color: Color("shadow"),
+                color: Color(.shadow),
                 radius: 10,
                 x: 0,
                 y: 0

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/View+Shadow.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/View+Shadow.swift
@@ -1,0 +1,24 @@
+//
+//  View+Shadow.swift
+//  Cherrish-iOS
+//
+
+import SwiftUI
+
+struct CherrishShadow: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .shadow(
+                color: Color("shadow"),
+                radius: 10,
+                x: 0,
+                y: 0
+            )
+    }
+}
+
+extension View {
+    func cherrishShadow() -> some View {
+        self.modifier(CherrishShadow())
+    }
+}

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/View+Shadow.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/View+Shadow.swift
@@ -9,8 +9,8 @@ struct CherrishShadow: ViewModifier {
     func body(content: Content) -> some View {
         content
             .shadow(
-                color: Color(.shadow),
-                radius: 10,
+                color: Color(.shadow).opacity(0.12),
+                radius: 5,
                 x: 0,
                 y: 0
             )


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #36 

## 📄 작업 내용
- Color ViewModifier 추가
- Shadow 디자인 시스템 반영
- Color 디자인 시스템 반영 Green Color 추가 

## 💻 주요 코드 설명
```swift
struct CherrishShadow: ViewModifier {
    func body(content: Content) -> some View {
        content
            .shadow(
                color: Color(.shadow).opacity(0.12),
                radius: 5,
                x: 0,
                y: 0
            )
    }
}

extension View {
    func cherrishShadow() -> some View {
        self.modifier(CherrishShadow())
    }
}
```
Blur 10 (SwiftUI radius = blur/2) 라네요

---


Color ViewModifier
```swift
extension View {
    func gray0() -> some View {
        self.foregroundStyle(Color("gray_0"))
    }
}
```

## 사용 방법
- `.cherrishShadow()`로 쉐도우 사용
- 컬러는 이제 `.red_100()`으로 사용가능

## 👀 기타 더 이야기해볼 점
파일 네이밍, 위치 지적 받습니다.

쉐도우의 경우 
현재 파일 이름은 `View+Shadow`이고 위치는 Global/Extension 안에 있습니다.

컬러의 경우
`View+Color`이고 위치는 Global/Extension 안에 있습니다.
