### PR TITLE
feat/#50 Month Plan 컴포넌트 추가

### DIFF
--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/MonthPlan.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/MonthPlan.swift
@@ -20,26 +20,26 @@ struct MonthPlan: View {
             TypographyText("회복 \(dDay)일차", style: .body1_r_14, color: Self.textColor)
             
             Spacer()
-                .frame(width: 6)
+                .frame(width: 6.adjustedW)
             
             TypographyText(tag, style: .body3_r_12, color: .gray700)
-                .frame(width: 32, height: 22)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 2)
+                .frame(width: 32.adjustedW, height: 22.adjustedH)
+                .padding(.horizontal, 8.adjustedW)
+                .padding(.vertical, 2.adjustedH)
                 .background(
-                    RoundedRectangle(cornerRadius: 20)
-                        .strokeBorder(.gray400, lineWidth: 1)
+                    RoundedRectangle(cornerRadius: 20.adjustedW)
+                        .strokeBorder(.gray400, lineWidth: 1.adjustedW)
                 )
             
             Spacer()
         }
-        .padding(.vertical, 12)
-        .padding(.horizontal, 14)
+        .padding(.vertical, 12.adjustedH)
+        .padding(.horizontal, 14.adjustedW)
         .background(.gray0)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .clipShape(RoundedRectangle(cornerRadius: 10.adjustedW))
         .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .strokeBorder(.gray400, lineWidth: 1)
+            RoundedRectangle(cornerRadius: 10.adjustedW)
+                .strokeBorder(.gray400, lineWidth: 1.adjustedW)
         )
     }
 }

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/MonthPlan.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/MonthPlan.swift
@@ -11,53 +11,40 @@ struct MonthPlan: View {
     let interaction: String
     let dDay: Int
     let tag: String
-    
     private static let textColor: Color = .gray900
-    private static let tagTextColor: Color = .gray700
-    private static let tagBorderColor: Color = .gray400
-    private static let containerBorderColor: Color = .gray400
-    private static let containerBackgroundColor: Color = .gray0
-    
-    private static let tagSpacing: CGFloat = 6
-    private static let tagPaddingHorizontal: CGFloat = 8
-    private static let tagPaddingVertical: CGFloat = 2
-    private static let tagBorderWidth: CGFloat = 1
-    private static let tagCornerRadius: CGFloat = 20
-    private static let containerPaddingVertical: CGFloat = 12
-    private static let containerPaddingLeading: CGFloat = 14
-    private static let cornerRadius: CGFloat = 10
-    private static let containerBorderWidth: CGFloat = 1
     
     var body: some View {
         HStack(spacing: 0) {
-            
             TypographyText(interaction, style: .body1_m_14, color: Self.textColor)
-            
             TypographyText(" • ", style: .body1_m_14, color: Self.textColor)
-            
             TypographyText("회복 \(dDay)일차", style: .body1_r_14, color: Self.textColor)
             
             Spacer()
-                .frame(width: Self.tagSpacing)
+                .frame(width: 6)
             
-            TypographyText(tag, style: .body3_r_12, color: Self.tagTextColor)
+            TypographyText(tag, style: .body3_r_12, color: .gray700)
                 .frame(width: 32, height: 22)
-                .padding(.horizontal, Self.tagPaddingHorizontal)
-                .padding(.vertical, Self.tagPaddingVertical)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
                 .background(
-                    RoundedRectangle(cornerRadius: Self.tagCornerRadius)
-                        .strokeBorder(Self.tagBorderColor, lineWidth: Self.tagBorderWidth)
+                    RoundedRectangle(cornerRadius: 20)
+                        .strokeBorder(.gray400, lineWidth: 1)
                 )
             
             Spacer()
         }
-        .padding(.vertical, Self.containerPaddingVertical)
-        .padding(.leading, Self.containerPaddingLeading)
-        .background(Self.containerBackgroundColor)
-        .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
+        .padding(.vertical, 12)
+        .padding(.horizontal, 14)
+        .background(.gray0)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
         .overlay(
-            RoundedRectangle(cornerRadius: Self.cornerRadius)
-                .strokeBorder(Self.containerBorderColor, lineWidth: Self.containerBorderWidth)
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(.gray400, lineWidth: 1)
         )
     }
+}
+
+#Preview {
+    MonthPlan(interaction: "복합 박피", dDay: 7, tag: "주의기")
+        .padding()
 }

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/MonthPlan.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/MonthPlan.swift
@@ -37,10 +37,11 @@ struct MonthPlan: View {
             
             TypographyText("회복 \(dDay)일차", style: .body1_r_14, color: Self.textColor)
             
-            Spacer().frame(width: Self.tagSpacing)
+            Spacer()
+                .frame(width: Self.tagSpacing)
             
             TypographyText(tag, style: .body3_r_12, color: Self.tagTextColor)
-                .frame(width: 32, height: 18)
+                .frame(width: 32, height: 22)
                 .padding(.horizontal, Self.tagPaddingHorizontal)
                 .padding(.vertical, Self.tagPaddingVertical)
                 .background(
@@ -60,4 +61,3 @@ struct MonthPlan: View {
         )
     }
 }
-

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/MonthPlan.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/MonthPlan.swift
@@ -1,0 +1,63 @@
+//
+//  MonthPlan.swift
+//  Cherrish-iOS
+//
+//  Created by 송성용 on 1/13/26.
+//
+
+import SwiftUI
+
+struct MonthPlan: View {
+    let interaction: String
+    let dDay: Int
+    let tag: String
+    
+    private static let textColor: Color = .gray900
+    private static let tagTextColor: Color = .gray700
+    private static let tagBorderColor: Color = .gray400
+    private static let containerBorderColor: Color = .gray400
+    private static let containerBackgroundColor: Color = .gray0
+    
+    private static let tagSpacing: CGFloat = 6
+    private static let tagPaddingHorizontal: CGFloat = 8
+    private static let tagPaddingVertical: CGFloat = 2
+    private static let tagBorderWidth: CGFloat = 1
+    private static let tagCornerRadius: CGFloat = 20
+    private static let containerPaddingVertical: CGFloat = 12
+    private static let containerPaddingLeading: CGFloat = 14
+    private static let cornerRadius: CGFloat = 10
+    private static let containerBorderWidth: CGFloat = 1
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            
+            TypographyText(interaction, style: .body1_m_14, color: Self.textColor)
+            
+            TypographyText(" • ", style: .body1_m_14, color: Self.textColor)
+            
+            TypographyText("회복 \(dDay)일차", style: .body1_r_14, color: Self.textColor)
+            
+            Spacer().frame(width: Self.tagSpacing)
+            
+            TypographyText(tag, style: .body3_r_12, color: Self.tagTextColor)
+                .frame(width: 32, height: 18)
+                .padding(.horizontal, Self.tagPaddingHorizontal)
+                .padding(.vertical, Self.tagPaddingVertical)
+                .background(
+                    RoundedRectangle(cornerRadius: Self.tagCornerRadius)
+                        .strokeBorder(Self.tagBorderColor, lineWidth: Self.tagBorderWidth)
+                )
+            
+            Spacer()
+        }
+        .padding(.vertical, Self.containerPaddingVertical)
+        .padding(.leading, Self.containerPaddingLeading)
+        .background(Self.containerBackgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: Self.cornerRadius)
+                .strokeBorder(Self.containerBorderColor, lineWidth: Self.containerBorderWidth)
+        )
+    }
+}
+


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #50 

## 📄 작업 내용
- Month Plan 컴포넌트 추가

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img width="250" src="https://github.com/user-attachments/assets/2c56897e-7f09-4d64-a3c0-5460c4ab9c10" /> | <img width="250" src="https://github.com/user-attachments/assets/c03f7a56-5384-4dc6-88bf-a11c025b9a94" /> |


## 사용법
```swift
ForEach(procedures) { procedure in
    MonthPlan(
        interaction: procedure.name,
        dDay: procedure.recoveryDay,
        tag: procedure.status
    )
}
```
