### PR TITLE
Feat/#52 기기대응 익스텐션

### DIFF
--- a/Cherrish-iOS/Cherrish-iOS/Info.plist
+++ b/Cherrish-iOS/Cherrish-iOS/Info.plist
@@ -10,6 +10,6 @@
 		<string>Pretendard-SemiBold.otf</string>
 	</array>
 	<key>UIDesignRequiresCompatibility</key>
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Component/Tabbar/CherrishTabBar.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Component/Tabbar/CherrishTabBar.swift
@@ -60,7 +60,7 @@ struct CherrishTabBar: View {
                     VStack(alignment: .center, spacing: 3) {
                         Image(selectedTab == tab ? tab.selectedIcon : tab.defaultIcon)
                             .resizable()
-                            .frame(width: 24, height: 24)
+                            .frame(width: 24.adjustedW, height: 24.adjustedW)
                         Text(tab.title)
                             .typography(.body3_m_12)
                             .foregroundColor(selectedTab == tab ? .gray1000 : .gray500)
@@ -69,9 +69,9 @@ struct CherrishTabBar: View {
                 }
             }
         }
-        .padding(.horizontal, 24.5)
-        .padding(.top, 10)
-        .frame(height: 54)
+        .padding(.horizontal, 24.5.adjustedW)
+        .padding(.top, 10.adjustedH)
+        .frame(height: 54.adjustedH)
         
     }
 }

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishButton.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishButton.swift
@@ -62,9 +62,9 @@ extension CherrishButtonType {
     
     var height: CGFloat {
         switch self {
-        case .save: return 44
+        case .save: return 44.adjustedH
         default:
-            return 50
+            return 50.adjustedH
         }
     }
     
@@ -106,69 +106,3 @@ extension CherrishButtonType {
         }
     }
 }
-
-
-struct CherrishButtonPreviewWrapper: View {
-    
-    @State private var nextState: ButtonState = .normal
-    @State private var activeNextState: ButtonState = .active
-    @State private var dummyState: ButtonState = .active
-
-    var body: some View {
-        VStack(spacing: 16) {
-
-            // NEXT - 비활성
-            CherrishButton(
-                title: "다음",
-                type: .next,
-                state: $nextState
-            ) {
-                print("Next (normal)")
-            }
-
-            // NEXT - 활성
-            CherrishButton(
-                title: "다음",
-                type: .next,
-                state: $activeNextState
-            ) {
-                print("Next (active)")
-            }
-            .padding(CGFloat(8))
-
-            // CONFIRM
-            CherrishButton(
-                title: "확인",
-                type: .confirm,
-                state: $dummyState
-            ) {
-                print("Confirm")
-            }
-
-            // SAVE
-            CherrishButton(
-                title: "등록하기",
-                type: .save,
-                state: $dummyState
-            ) {
-                print("Save")
-            }
-
-            // ADD EVENT
-            CherrishButton(
-                title: "다운타임 없이 일정 추가",
-                type: .addEvent,
-                state: $dummyState
-            ) {
-                print("Add Event")
-            }
-        }
-        .padding()
-        .background(Color.gray100)
-    }
-}
-#Preview {
-    CherrishButtonPreviewWrapper()
-}
-
-

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishNavigationBar.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishNavigationBar.swift
@@ -56,8 +56,8 @@ struct CherrishNavigationBar: View {
             }
             
         }
-        .frame(height: 44)
-        .padding(.vertical, 8)
+        .frame(height: 44.adjustedH)
+        .padding(.vertical, 8.adjustedH)
         
     }
 }

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/MissionCard.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/MissionCard.swift
@@ -25,13 +25,13 @@ struct MissionCard: View {
             Text(missionText)
                 .typography(.body1_m_14)
                 .foregroundStyle(isSelected ? .gray800 : .gray700)
-                .padding(.leading, 8)
-                .padding(.bottom, 6)
+                .padding(.leading, 8.adjustedW)
+                .padding(.bottom, 6.adjustedH)
         }
-        .padding(.horizontal, 7)
-        .padding(.vertical, 6)
+        .padding(.horizontal, 7.adjustedW)
+        .padding(.vertical, 6.adjustedH)
         .frame(maxWidth: .infinity)
-        .frame(height: 80)
+        .frame(height: 80.adjustedH)
         .background(isSelected ? .red200 : .gray0)
         .overlay(
             RoundedRectangle(cornerRadius: 10)

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/SelectionChip.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/SelectionChip.swift
@@ -17,7 +17,7 @@ struct SelectionChip: View {
             .typography(.body1_m_14)
             .foregroundStyle(isSelected ? .gray800 : .gray700)
             .frame(maxWidth: .infinity)
-            .frame(height: 80)
+            .frame(height: 80.adjustedH)
             .background(isSelected ? .red200 : .gray0)
             .overlay(
                 RoundedRectangle(cornerRadius: 10)

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/Adjust+.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Extension/Adjust+.swift
@@ -1,0 +1,43 @@
+//
+//  Adjust+.swift
+//  Cherrish-iOS
+//
+//  Created by 이나연 on 1/13/26.
+//
+
+import Foundation
+import UIKit
+
+extension CGFloat {
+    var adjustedW: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        return self * ratio
+    }
+    
+    var adjustedH: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.height / 812
+        return self * ratio
+    }
+}
+
+extension Double {
+    var adjustedW: Double {
+        let ratio: Double = Double(UIScreen.main.bounds.width / 375)
+        return self * ratio
+    }
+    
+    var adjustedH: Double {
+        let ratio: Double = Double(UIScreen.main.bounds.height / 812)
+        return self * ratio
+    }
+}
+
+extension Int {
+    var adjustedW: CGFloat {
+        return CGFloat(self).adjustedW
+    }
+    
+    var adjustedH: CGFloat {
+        return CGFloat(self).adjustedH
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Closed: #52

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 기기대응 익스텐션 추가했습니다

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/b5121bb0-8526-431b-b951-0e7a2cdaf25b" width ="250"> | <img src = "https://github.com/user-attachments/assets/17d83eaa-0b9c-4f87-a4b7-d5cdce95c4a4" width ="250"> |


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
```swift
 var adjustedW: CGFloat {
        let ratio: CGFloat = UIScreen.main.bounds.width / 375
        return self * ratio
    }
    
  var adjustedH: CGFloat {
      let ratio: CGFloat = UIScreen.main.bounds.height / 812
      return self * ratio
  }
```
화면 크기 비율을 계산해서 다시 적용하는 익스텐션입니다. 
호리존탈에는 adjustedW를, 버티컬에는 adjustedH를 적용해주시면 됩니다 
