### PR TITLE
Fix/#75 탭바 리팩토링

### DIFF
--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Feature/ChallengeView/Coordinator/ChallengeCoordinatorView.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Feature/ChallengeView/Coordinator/ChallengeCoordinatorView.swift
@@ -25,9 +25,9 @@ struct ChallengeCoordinatorView: View {
                                 .onAppear() {
                                     tabBarCoordinator.isTabbarHidden = true
                                 }
-                                .onDisappear {
-                                    tabBarCoordinator.isTabbarHidden = false
-                                }
+//                                .onDisappear {
+//                                    tabBarCoordinator.isTabbarHidden = false
+//                                }
                         case .loading:
                             ViewFactory.shared.makeLoadingView()
                                 .onAppear() {

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Feature/ChallengeView/Coordinator/ChallengeCoordinatorView.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Feature/ChallengeView/Coordinator/ChallengeCoordinatorView.swift
@@ -25,9 +25,6 @@ struct ChallengeCoordinatorView: View {
                                 .onAppear() {
                                     tabBarCoordinator.isTabbarHidden = true
                                 }
-//                                .onDisappear {
-//                                    tabBarCoordinator.isTabbarHidden = false
-//                                }
                         case .loading:
                             ViewFactory.shared.makeLoadingView()
                                 .onAppear() {

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishTabbar/CherrishTabBar.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishTabbar/CherrishTabBar.swift
@@ -71,7 +71,8 @@ struct CherrishTabBar: View {
         }
         .padding(.horizontal, 24.5.adjustedW)
         .padding(.top, 10.adjustedH)
+        .ignoresSafeArea()
+        .background(.gray0)
         .frame(height: 54.adjustedH)
-        
     }
 }

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishTabbar/TabBarCoordinatorView.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishTabbar/TabBarCoordinatorView.swift
@@ -13,28 +13,42 @@ struct TabBarCoordinatorView: View {
     
     var body: some View {
         ZStack(alignment: .bottom) {
-            TabView(selection: $tabBarCoordinator.selectedTab) {
-                HomeCoordinatorView()
-                    .tag(CherrishTab.home)
-                    .environmentObject(tabBarCoordinator.homeCoordinator)
-                
-                CalendarCoordinatorView()
-                    .tag(CherrishTab.calendar)
-                    .environmentObject(tabBarCoordinator.calendarCoordinator)
-                
-                ChallengeCoordinatorView()
-                    .tag(CherrishTab.challenge)
-                    .environmentObject(tabBarCoordinator.challengeCoordinator)
-                            
-                MyPageCoordinatorView()
-                    .tag(CherrishTab.mypage)
-                    .environmentObject(tabBarCoordinator.mypageCoordinator)
+            Group{
+                switch tabBarCoordinator.selectedTab {
+                case .home:
+                    HomeCoordinatorView()
+                        .environmentObject(tabBarCoordinator.homeCoordinator)
+                case .calendar:
+                    CalendarCoordinatorView()
+                        .environmentObject(tabBarCoordinator.calendarCoordinator)
+                case .challenge:
+                    ChallengeCoordinatorView()
+                        .environmentObject(tabBarCoordinator.challengeCoordinator)
+                case .mypage:
+                    MyPageCoordinatorView()
+                        .environmentObject(tabBarCoordinator.mypageCoordinator)
+                }
             }
-            
+            .padding(.bottom, tabBarCoordinator.isTabbarHidden ? 0 : 54.adjustedH)
+            .id(tabBarCoordinator.selectedTab)
+            .environmentObject(tabBarCoordinator)
             if !tabBarCoordinator.isTabbarHidden {
                 CherrishTabBar(selectedTab: $tabBarCoordinator.selectedTab)
             }
         }
         .environmentObject(tabBarCoordinator)
+        .onChange(of: tabBarCoordinator.selectedTab) { newTab in
+            switch newTab {
+            case .home:
+                tabBarCoordinator.homeCoordinator.popToRoot()
+            case .calendar:
+                tabBarCoordinator.calendarCoordinator.popToRoot()
+            case .challenge:
+                tabBarCoordinator.challengeCoordinator.popToRoot()
+            case .mypage:
+                tabBarCoordinator.mypageCoordinator.popToRoot()
+            }
+            
+        }
     }
 }

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishTabbar/TabBarCoordinatorView.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishTabbar/TabBarCoordinatorView.swift
@@ -37,7 +37,7 @@ struct TabBarCoordinatorView: View {
             }
         }
         .environmentObject(tabBarCoordinator)
-        .onChange(of: tabBarCoordinator.selectedTab) { newTab in
+        .onChange(of: tabBarCoordinator.selectedTab) { oldTab, newTab in
             switch newTab {
             case .home:
                 tabBarCoordinator.homeCoordinator.popToRoot()
@@ -48,7 +48,6 @@ struct TabBarCoordinatorView: View {
             case .mypage:
                 tabBarCoordinator.mypageCoordinator.popToRoot()
             }
-            
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Closed: #75

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 탭바 리팩토링했습니다 ~  (shout out 대한열님) 

|    구현 내용    |   IPhone 13  |  
| :-------------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/e0b9133d-598f-4a75-8a6b-e45e6b514ba0" width = "250"> |

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`코드 설명할 파일 이름 (ex: HomeView)`
- 어쩌구저쩌구
```swift
ZStack(alignment: .bottom) {
            Group{
                switch tabBarCoordinator.selectedTab {
                case .home:
                    HomeCoordinatorView()
                        .environmentObject(tabBarCoordinator.homeCoordinator)
                case .calendar:
                    CalendarCoordinatorView()
                        .environmentObject(tabBarCoordinator.calendarCoordinator)
                case .challenge:
                    ChallengeCoordinatorView()
                        .environmentObject(tabBarCoordinator.challengeCoordinator)
                case .mypage:
                    MyPageCoordinatorView()
                        .environmentObject(tabBarCoordinator.mypageCoordinator)
                }
            }
            .padding(.bottom, tabBarCoordinator.isTabbarHidden ? 0 : 54.adjustedH)
            .id(tabBarCoordinator.selectedTab)
            .environmentObject(tabBarCoordinator)
            if !tabBarCoordinator.isTabbarHidden {
                CherrishTabBar(selectedTab: $tabBarCoordinator.selectedTab)
            }
        }
```
원래 ZStack에 스위프트 탭뷰를 올렸는데  탭뷰를 지우는 방식으로 수정했습니다. 

```swift
.onChange(of: tabBarCoordinator.selectedTab) { oldTab, newTab in
            switch newTab {
            case .home:
                tabBarCoordinator.homeCoordinator.popToRoot()
            case .calendar:
                tabBarCoordinator.calendarCoordinator.popToRoot()
            case .challenge:
                tabBarCoordinator.challengeCoordinator.popToRoot()
            case .mypage:
                tabBarCoordinator.mypageCoordinator.popToRoot()
            }
        }
```
그리고 탭이 눌릴 때 네비게이션 스택을 초기화하는 쪽으로 수정했습니다. 
