### PR TITLE
Style/#104 온보딩 뷰 패딩 간격 수정

### DIFF
--- a/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/splash/Contents.json
+++ b/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/splash/Contents.json
@@ -1,6 +1,0 @@
-{
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
-}

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Feature/Onboarding/OnboardingPage1.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Feature/Onboarding/OnboardingPage1.swift
@@ -41,11 +41,11 @@ struct OnboardingPage1: View {
                     Rectangle()
                         .fill(Color.red700)
                         .frame(width: 252.adjustedW, height: 1.4)
-                        .padding(.leading, 4)
+                        .padding(.leading, 4.adjustedW)
                     Rectangle()
                         .fill(Color.red700)	
                         .frame(width: 260.adjustedW, height: 1.4) 
-                        .padding(.top, 3)
+                        .padding(.top, 3.adjustedH)
                     
                     TypographyText("일정을 한 눈에 정리해드려요", style: .title1_sb_18, color: .gray1000)
                         .padding(.top, 6.adjustedH)

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Feature/Onboarding/OnboardingPage1.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Feature/Onboarding/OnboardingPage1.swift
@@ -41,6 +41,7 @@ struct OnboardingPage1: View {
                     Rectangle()
                         .fill(Color.red700)
                         .frame(width: 252.adjustedW, height: 1.4)
+                        .padding(.leading, 4)
                     Rectangle()
                         .fill(Color.red700)	
                         .frame(width: 260.adjustedW, height: 1.4) 


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #104 

## 📄 작업 내용
- 온보딩 뷰 패딩 간격 수정

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img width="426" height="856" alt="image" src="https://github.com/user-attachments/assets/a71d0223-d339-4383-b261-9c5d090b424a" /> | <img width="405" height="818" alt="image" src="https://github.com/user-attachments/assets/cf4b1f08-0a1a-4709-9c28-a9e3bcad4758" /> |

네,,, 패딩 4px만 옮겼습니다 어푸 부탁드려요 

그 화면에 두번째줄 텍스트 잘리는건 나연누나 탭바 변경사항 머지되고 수정해야할 거 같아요