### PR TITLE
Feat/#109 피커 실시간 변동 적용

### DIFF
--- a/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/Splash/Contents.json
+++ b/Cherrish-iOS/Cherrish-iOS/Assets.xcassets/Splash/Contents.json
@@ -1,6 +1,0 @@
-{
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
-}

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishPicker.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishPicker.swift
@@ -41,12 +41,28 @@ private struct PickerViewRepresentable: UIViewRepresentable {
         }
         
         let row = selection - range.lowerBound
-        picker.selectRow(row, inComponent: 0, animated: true)
+        picker.selectRow(row, inComponent: 0, animated: false)
+        
+        DispatchQueue.main.async {
+            self.findAndConnectScrollViews(in: picker, coordinator: context.coordinator)
+        }
         
         return picker
     }
     
+    private func findAndConnectScrollViews(in view: UIView, coordinator: Coordinator) {
+        for subview in view.subviews {
+            if let scrollView = subview as? UIScrollView {
+                coordinator.originalScrollViewDelegate = scrollView.delegate
+                scrollView.delegate = coordinator
+            }
+            findAndConnectScrollViews(in: subview, coordinator: coordinator)
+        }
+    }
+    
     func updateUIView(_ uiView: UIPickerView, context: Context) {
+        guard !context.coordinator.isScrolling else { return }
+        
         let row = selection - range.lowerBound
         if uiView.selectedRow(inComponent: 0) != row {
             uiView.selectRow(row, inComponent: 0, animated: true)
@@ -59,8 +75,11 @@ private struct PickerViewRepresentable: UIViewRepresentable {
 }
 
 extension PickerViewRepresentable {
-    class Coordinator: NSObject, UIPickerViewDelegate, UIPickerViewDataSource {
+    class Coordinator: NSObject, UIPickerViewDelegate, UIPickerViewDataSource, UIScrollViewDelegate {
         var parent: PickerViewRepresentable
+        private let rowHeight: CGFloat = 44.adjustedH
+        var isScrolling: Bool = false
+        weak var originalScrollViewDelegate: UIScrollViewDelegate?
         
         init(_ parent: PickerViewRepresentable) {
             self.parent = parent
@@ -75,13 +94,14 @@ extension PickerViewRepresentable {
         }
         
         func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+            isScrolling = false
             parent.selection = parent.range.lowerBound + row
         }
         
         func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
             pickerView.subviews.forEach { subview in
-                   subview.backgroundColor = .clear
-               }
+                subview.backgroundColor = .clear
+            }
             
             let label = (view as? UILabel) ?? UILabel()
             label.text = "\(parent.range.lowerBound + row)"
@@ -97,6 +117,48 @@ extension PickerViewRepresentable {
         
         func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
             60.adjustedW
+        }
+        
+        private var initialContentOffset: CGFloat = 0
+        private var initialRow: Int = 0
+        
+        func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+            isScrolling = true
+            initialContentOffset = scrollView.contentOffset.y
+            initialRow = parent.selection - parent.range.lowerBound
+            originalScrollViewDelegate?.scrollViewWillBeginDragging?(scrollView)
+        }
+        
+        func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+            originalScrollViewDelegate?.scrollViewDidEndDragging?(scrollView, willDecelerate: decelerate)
+        }
+        
+        func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+            originalScrollViewDelegate?.scrollViewDidEndDecelerating?(scrollView)
+        }
+        
+        func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+            originalScrollViewDelegate?.scrollViewWillEndDragging?(scrollView, withVelocity: velocity, targetContentOffset: targetContentOffset)
+        }
+        
+        func scrollViewDidScroll(_ scrollView: UIScrollView) {
+            originalScrollViewDelegate?.scrollViewDidScroll?(scrollView)
+            
+            guard isScrolling else { return }
+            
+            let deltaOffset = scrollView.contentOffset.y - initialContentOffset
+            let deltaRow = Int(round(deltaOffset / rowHeight))
+            let newRow = initialRow + deltaRow
+            let clampedRow = max(0, min(newRow, parent.range.count - 1))
+            let newSelection = parent.range.lowerBound + clampedRow
+            
+            if parent.selection != newSelection {
+                parent.selection = newSelection
+            }
+        }
+        
+        func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+            originalScrollViewDelegate?.scrollViewDidEndScrollingAnimation?(scrollView)
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #109 

## 📄 작업 내용
- 피커 실시간 동기화 적용

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | ![Simulator Screen Recording - iPhone 17 Pro - 2026-01-20 at 23 22 46](https://github.com/user-attachments/assets/45909521-f109-43f9-ad47-9664f3bba480) | ![Simulator Screen Recording - iPhone 13 mini - 2026-01-20 at 23 26 50](https://github.com/user-attachments/assets/9a0114b4-1381-4d77-a6bf-ad919b8962b8) |


## 💻 주요 코드 설명
실시간 감지를 위해 **내부 스크롤 뷰를 찾아내서 델리게이트를 가로채는 과정**이 추가함으로써 해결했습니다.

```swift
func makeUIView(context: Context) -> UIPickerView {
    let picker = UIPickerView()
    picker.delegate = context.coordinator
    picker.dataSource = context.coordinator
    
    // 피커 내부의 스크롤 뷰를 찾아서 델리게이트를 Coordinator로 위임
    picker.subviews.forEach { subview in
        subview.backgroundColor = .clear 
        
        // 변경점
        if let scrollView = subview as? UIScrollView {
            scrollView.delegate = context.coordinator
        }
    }
    /// ...
    return picker
}
```

- **`if let scrollView = subview as? UIScrollView`**: `UIPickerView`는 겉으로는 피커지만, 내부적으로는 `UIScrollView`(또는 `UITableView`)로 구성되어 있습니다. 이 숨겨진 스크롤 뷰를 찾아냅니다.
- **`scrollView.delegate = context.coordinator`**: 원래는 피커 내부 로직이 스크롤을 관리하지만, 스크롤 되는 순간을 포착하기 위해 **Coordinator가 스크롤 델리게이트 권한을 가져옵니다.** 이렇게 해야 `scrollViewDidScroll` 이벤트를 받을 수 있습니다.

**기존 코드 (`didSelectRow`)**

```swift
// 스크롤이 멈췄을 때 1번 호출
funcpickerView(_pickerView: UIPickerView,didSelectRowrow:Int,inComponentcomponent:Int) {
    parent.selection= parent.range.lowerBound+ row
}

```

**실시간 코드 (`scrollViewDidScroll`)**

```swift
// 스크롤이 움직일 때마다 계속 호출됨
funcscrollViewDidScroll(_scrollView: UIScrollView) {
// 1. 현재 스크롤된 y 위치에서 행 높이 절반을 더해 중앙 보정
let yOffset= scrollView.contentOffset.y+ (44.adjustedH/2)

// 2. 높이로 나누어 현재 몇 번째 row인지 계산 (반올림 같은 효과)
var row=Int(yOffset/44.adjustedH)

// 3. 인덱스 범위 안전 장치 (0보다 작거나 최대 개수 넘지 않게)
    row=max(0,min(row, parent.range.count-1))

// 4. 값이 실제로 변했을 때만 SwiftUI 상태 업데이트
let newValue= parent.range.lowerBound+ row
if parent.selection!= newValue {
        parent.selection= newValue
    }
}

```

근데….. 이렇게 했을때 실시간 동기화는 해결했지만 UIPicker의 delegate를 뻇어왔기 때문에 손을 놨을때 자동으로 가까운 숫자로 가는 “스냅” 기능이 비활성화되는 문제가 발생했습니다.

그래서,,,,,,

스냅 기능을 아예 만들기….

```swift
// 사용자가 드래그를 끝내는 순간 호출됨
func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
    
    // 1. 예상되는 최종 정지 위치 (y좌표)
    let expectedY = targetContentOffset.pointee.y
    
    // 2. 행 높이
    let rowHeight = 44.adjustedH
    
    // 3. 가장 가까운 행의 인덱스를 계산
    var index = round(expectedY / rowHeight)
    
    // 4. 인덱스가 범위를 벗어나지 않도록 안전 장치 (0 ~ 마지막 인덱스)
    index = max(0, min(index, CGFloat(parent.range.count - 1)))
    
    // 5. 스냅 위치 보정
    // 시스템이 원래 멈추려던 위치 계산한 '정확한 칸 위치'로 덮어씌우기
    targetContentOffset.pointee = CGPoint(x: 0, y: index * rowHeight)
}
```
