### PR TITLE
Fix/#123 textfield 패딩 추가, "세" 자동 추가

### DIFF
--- a/Cherrish-iOS/Cherrish-iOS/Data/Network/EndPoint/OnboardingAPI.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Data/Network/EndPoint/OnboardingAPI.swift
@@ -41,7 +41,7 @@ enum OnboardingAPI: EndPoint {
         return JSONEncoding.default
     }
     
-    var queryParameters: [String: String]? {
+    var queryParameters: [String: Any]? {
         return nil
     }
     

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Feature/Onboarding/InformationView.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Feature/Onboarding/InformationView.swift
@@ -23,8 +23,13 @@ struct InformationView: View {
         name.count > 7
     }
     
+    private var ageNumericValue: Int? {
+        let numericString = age.replacingOccurrences(of: " 세", with: "")
+        return Int(numericString)
+    }
+    
     private var isAgeOverLimit: Bool {
-        guard let ageValue = Int(age) else { return false }
+        guard let ageValue = ageNumericValue else { return false }
         return ageValue > 100
     }
 
@@ -54,10 +59,10 @@ struct InformationView: View {
                             .offset(y: 24.adjustedH)
                     }
                 }
-                .padding(.top, 70.adjustedH)
+                .padding(.top, 70.adjustedH)    
                 .padding(.horizontal, 34.adjustedW)
             
-            CherrishTextBox(title: "나이",text: $age, placeholder: "20", isNumberField: true)
+            CherrishTextBox(title: "나이",text: $age, placeholder: "20 세", isNumberField: true)
                 .focused($isAgeFocused)
                 .overlay(alignment: .bottomLeading) {
                     if showAgeError {
@@ -78,7 +83,7 @@ struct InformationView: View {
                 trailingIcon: nil
             ) {
                 Task {
-                    guard let ageValue = Int(age) else { return }
+                    guard let ageValue = ageNumericValue else { return }
                     await viewModel.createProfile(name: name, age: ageValue)
                 }
             }
@@ -95,6 +100,9 @@ struct InformationView: View {
         .onChange(of: age) { _ in updateButtonState() }
         .onChange(of: isAgeFocused) { focused in
             if !focused {
+                if let numericValue = ageNumericValue, !age.hasSuffix(" 세") {
+                    age = "\(numericValue) 세"
+                }
                 showAgeError = isAgeOverLimit
             }
         }

--- a/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishTextField/CherrishTextField.swift
+++ b/Cherrish-iOS/Cherrish-iOS/Presentation/Global/Components/CherrishTextField/CherrishTextField.swift
@@ -79,7 +79,7 @@ enum CherrishTextFieldStyle {
         case .plain, .number:
             return 16.adjustedW
         case .date:
-            return 18.5.adjustedW
+            return 0
         }
     }
     
@@ -158,6 +158,7 @@ struct CherrishTextField: View {
                     .tint(style.textColor)
             }
             .frame(height: style.fontHeight)
+            .padding(.horizontal, style.horizontalPadding)
         }
         .padding(.vertical, style.verticalPadding)
         .background {


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #123 

## 📄 작업 내용
- 텍스트 필드 패딩 추가
- 나이 텍스트 필드 "세" 추가

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img width="420" height="853" alt="image" src="https://github.com/user-attachments/assets/bc501920-9e4d-41e4-95d2-48a227144f2f" /> | <img width="412" height="825" alt="image" src="https://github.com/user-attachments/assets/bd8076d1-8fb3-46db-a1d7-78d877807c5f" /> |


## 💻 주요 코드 설명
```swift
.onChange(of: isAgeFocused) { focused in
            if !focused {
                if let numericValue = ageNumericValue, !age.hasSuffix(" 세") {
                    age = "\(numericValue) 세"
                }
                showAgeError = isAgeOverLimit
            }
        }
```

```swift
    
    private var ageNumericValue: Int? {
        let numericString = age.replacingOccurrences(of: " 세", with: "")
        return Int(numericString)
    }
```